### PR TITLE
chore(reth-engine-tree): Replace HeadersClient + BodiesClient with Bl…

### DIFF
--- a/crates/engine/tree/src/download.rs
+++ b/crates/engine/tree/src/download.rs
@@ -4,9 +4,8 @@ use crate::{engine::DownloadRequest, metrics::BlockDownloaderMetrics};
 use futures::FutureExt;
 use reth_consensus::Consensus;
 use reth_network_p2p::{
-    bodies::client::BodiesClient,
     full_block::{FetchFullBlockFuture, FetchFullBlockRangeFuture, FullBlockClient},
-    headers::client::HeadersClient,
+    BlockClient,
 };
 use reth_primitives::{SealedBlock, SealedBlockWithSenders, B256};
 use std::{
@@ -47,7 +46,7 @@ pub enum DownloadOutcome {
 /// Basic [`BlockDownloader`].
 pub struct BasicBlockDownloader<Client>
 where
-    Client: HeadersClient + BodiesClient + Clone + Unpin + 'static,
+    Client: BlockClient + 'static,
 {
     /// A downloader that can download full blocks from the network.
     full_block_client: FullBlockClient<Client>,
@@ -66,7 +65,7 @@ where
 
 impl<Client> BasicBlockDownloader<Client>
 where
-    Client: HeadersClient + BodiesClient + Clone + Unpin + 'static,
+    Client: BlockClient + 'static,
 {
     /// Create a new instance
     pub fn new(client: Client, consensus: Arc<dyn Consensus>) -> Self {
@@ -175,7 +174,7 @@ where
 
 impl<Client> BlockDownloader for BasicBlockDownloader<Client>
 where
-    Client: HeadersClient + BodiesClient + Clone + Unpin + 'static,
+    Client: BlockClient + 'static,
 {
     /// Handles incoming download actions.
     fn on_action(&mut self, action: DownloadAction) {


### PR DESCRIPTION
…ockClient

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified the `BasicBlockDownloader` interface, now requiring only the `BlockClient` trait.
	- Enhanced compatibility for the downloader with a broader range of client types.
- **Refactor**
	- Removed unnecessary trait bounds (`Clone` and `Unpin`) for improved flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->